### PR TITLE
Move apikey in application config

### DIFF
--- a/chapter_2/2_4/id3.ex
+++ b/chapter_2/2_4/id3.ex
@@ -8,17 +8,21 @@ defmodule ID3Parser do
 
         << _ :: binary-size(mp3_byte_size), id3_tag :: binary >> = mp3
 
-        << "TAG", title   :: binary-size(30),                             
+        << "TAG", title   :: binary-size(30),
                   artist  :: binary-size(30),
                   album   :: binary-size(30),
                   year    :: binary-size(4),
-                  _rest   :: binary >>       = id3_tag                  
+                  _rest   :: binary >>       = id3_tag
+
+        title  = String.trim title, <<0>>
+        artist = String.trim artist, <<0>>
+        album  = String.trim album, <<0>>
+
         IO.puts "#{artist} - #{title} (#{album}, #{year})"
 
-      _ ->                                                        
+      _ ->
         IO.puts "Couldn't open #{file_name}"
 
     end
   end
 end
-

--- a/chapter_3/metex/config/config.exs
+++ b/chapter_3/metex/config/config.exs
@@ -2,6 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :metex,
+  api_key: "969038ec2b87be02c5f1e3f1344ee286"
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/chapter_3/metex/lib/worker.ex
+++ b/chapter_3/metex/lib/worker.ex
@@ -7,11 +7,11 @@ defmodule Metex.Worker do
       _ ->
         IO.puts "don't know how to process this message"
     end
-    loop 
+    loop
   end
 
   defp temperature_of(location) do
-    result = url_for(location) |> HTTPoison.get |> parse_response 
+    result = url_for(location) |> HTTPoison.get |> parse_response
     case result do
       {:ok, temp} ->
         "#{location}: #{temp}°C"
@@ -43,7 +43,7 @@ defmodule Metex.Worker do
   end
 
   defp apikey do
-    "969038ec2b87be02c5f1e3f1344ee286"
+    Application.fetch_env!(:metex, :api_key)
   end
 
 end

--- a/chapter_4/metex/config/config.exs
+++ b/chapter_4/metex/config/config.exs
@@ -2,6 +2,9 @@
 # and its dependencies with the aid of the Mix.Config module.
 use Mix.Config
 
+config :metex,
+  api_key: "969038ec2b87be02c5f1e3f1344ee286"
+
 # This configuration is loaded before any dependency and is restricted
 # to this project. If another project depends on this project, this
 # file won't be loaded nor affect the parent project. For this reason,

--- a/chapter_4/metex/lib/worker.ex
+++ b/chapter_4/metex/lib/worker.ex
@@ -39,12 +39,12 @@ defmodule Metex.Worker do
 
       _ ->
 
-        {:reply, :error, stats}  
+        {:reply, :error, stats}
     end
   end
 
   def handle_call(:get_stats, _from, stats) do
-    {:reply, stats, stats}  
+    {:reply, stats, stats}
   end
 
   def handle_cast(:reset_stats, _stats) do
@@ -70,7 +70,7 @@ defmodule Metex.Worker do
   ## Helper Functions
 
   defp temperature_of(location) do
-    url_for(location) |> HTTPoison.get |> parse_response 
+    url_for(location) |> HTTPoison.get |> parse_response
   end
 
   defp url_for(location) do
@@ -105,7 +105,7 @@ defmodule Metex.Worker do
   end
 
   defp apikey do
-    "969038ec2b87be02c5f1e3f1344ee286"
+    Application.fetch_env!(:metex, :api_key)
   end
 
 end


### PR DESCRIPTION
Maybe could be a good idea move the api key in `config.exs` just to illustrate an additional and useful way to manage configuration? 

Moreover, in the mp3 example, when I run the code in iex I see strange characters as:

```
iex(1)> ID3Parser.parse "/Users/ursus/Music/Amazon-Music-Download/Calcutta/Mainstream (Deluxe Edition)/01 - Gaetano.mp3"
Calcutta^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@ - Gaetano^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@^@ (Mainstream (Deluxe Edition)^@^@^@, 2016)
```

I solved this issue with these lines but probably there's a more suitable solution.

```
 title  = String.trim title, <<0>>
 artist = String.trim artist, <<0>>
 album  = String.trim album, <<0>>
```

Anyway, great book :)
