### PR TITLE
Fix restart_child callback function to support new_child_spec

### DIFF
--- a/chapter_5/thy_supervisor/lib/thy_supervisor.ex
+++ b/chapter_5/thy_supervisor/lib/thy_supervisor.ex
@@ -62,10 +62,10 @@ defmodule ThySupervisor do
     end
   end
 
-  def handle_call({:restart_child, old_pid}, _from, state) do
+  def handle_call({:restart_child, old_pid, new_child_spec}, _from, state) do
     case HashDict.fetch(state, old_pid) do
-      {:ok, child_spec} ->
-        case restart_child(old_pid, child_spec) do
+      {:ok, _} ->
+        case restart_child(old_pid, new_child_spec) do
           {:ok, {pid, child_spec}} ->
             new_state = state
                           |> HashDict.delete(old_pid)


### PR DESCRIPTION
The current version `ThySupervisor.restart_child` does not work  because `restart_child` api will call with /3 but `handle_call` callback for `:restart_child`  only support for /2. 