### PR TITLE
Make status consistent when a worker crashes

### DIFF
--- a/chapter_7/pooly/version-2/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-2/lib/pooly/server.ex
@@ -100,7 +100,7 @@ defmodule Pooly.Server do
       [{pid, ref}] ->
         true = Process.demonitor(ref)
         true = :ets.delete(monitors, pid)
-        new_state = %{state | workers: [new_worker(worker_sup)|workers]}
+        new_state = %{state | workers: [new_worker(worker_sup) | List.delete(workers, pid)]}
         {:noreply, new_state}
 
       [] ->


### PR DESCRIPTION
When a worker crashes, we need to remove it from state[:workers].