### PR TITLE
Pooly version 3 update

### DIFF
--- a/chapter_7/pooly/version-1/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-1/lib/pooly/server.ex
@@ -44,7 +44,7 @@ defmodule Pooly.Server do
   end
 
   def init([], state) do
-    send(self, :start_worker_supervisor)
+    send(self(), :start_worker_supervisor)
     {:ok, state}
   end
 

--- a/chapter_7/pooly/version-1/lib/pooly/supervisor.ex
+++ b/chapter_7/pooly/version-1/lib/pooly/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Pooly.Supervisor do
 
   def init(pool_config) do
     children = [
-      worker(Pooly.Server, [self, pool_config])
+      worker(Pooly.Server, [self(), pool_config])
     ]
 
     opts = [strategy: :one_for_all]

--- a/chapter_7/pooly/version-1/mix.exs
+++ b/chapter_7/pooly/version-1/mix.exs
@@ -7,7 +7,7 @@ defmodule Pooly.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/chapter_7/pooly/version-2/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-2/lib/pooly/server.ex
@@ -45,7 +45,7 @@ defmodule Pooly.Server do
   end
 
   def init([], state) do
-    send(self, :start_worker_supervisor)
+    send(self(), :start_worker_supervisor)
     {:ok, state}
   end
 

--- a/chapter_7/pooly/version-2/lib/pooly/supervisor.ex
+++ b/chapter_7/pooly/version-2/lib/pooly/supervisor.ex
@@ -7,7 +7,7 @@ defmodule Pooly.Supervisor do
 
   def init(pool_config) do
     children = [
-      worker(Pooly.Server, [self, pool_config])
+      worker(Pooly.Server, [self(), pool_config])
     ]
 
     opts = [strategy: :one_for_all]

--- a/chapter_7/pooly/version-2/mix.exs
+++ b/chapter_7/pooly/version-2/mix.exs
@@ -7,7 +7,7 @@ defmodule Pooly.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/chapter_7/pooly/version-3/lib/pooly/pool_supervisor.ex
+++ b/chapter_7/pooly/version-3/lib/pooly/pool_supervisor.ex
@@ -12,7 +12,7 @@ defmodule Pooly.PoolSupervisor do
     ]
 
     children = [
-      worker(Pooly.PoolServer, [self, pool_config])
+      worker(Pooly.PoolServer, [self(), pool_config])
     ]
 
     supervise(children, opts)

--- a/chapter_7/pooly/version-3/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-3/lib/pooly/server.ex
@@ -28,7 +28,7 @@ defmodule Pooly.Server do
 
   def init(pools_config) do
     pools_config |> Enum.each(fn(pool_config) ->
-      send(self, {:start_pool, pool_config})
+      send(self(), {:start_pool, pool_config})
     end)
 
     {:ok, pools_config}

--- a/chapter_7/pooly/version-3/lib/pooly/worker_supervisor.ex
+++ b/chapter_7/pooly/version-3/lib/pooly/worker_supervisor.ex
@@ -7,7 +7,8 @@ defmodule Pooly.WorkerSupervisor do
 
   def init([pool_server, {m,f,a}]) do
     Process.link(pool_server)
-    worker_opts = [shutdown: 5000,
+    worker_opts = [restart: :temporary,
+                   shutdown: 5000,
                    function: f]
 
     children = [worker(m, a, worker_opts)]

--- a/chapter_7/pooly/version-3/mix.exs
+++ b/chapter_7/pooly/version-3/mix.exs
@@ -7,7 +7,7 @@ defmodule Pooly.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do

--- a/chapter_7/pooly/version-4/lib/pooly/pool_server.ex
+++ b/chapter_7/pooly/version-4/lib/pooly/pool_server.ex
@@ -62,7 +62,7 @@ defmodule Pooly.PoolServer do
   end
 
   def init([], state) do
-    send(self, :start_worker_supervisor)
+    send(self(), :start_worker_supervisor)
     {:ok, state}
   end
 
@@ -266,7 +266,7 @@ defmodule Pooly.PoolServer do
     # NOTE: The reason this is set to temporary is because the WorkerSupervisor
     #       is started by the PoolServer.
     opts = [id: name <> "WorkerSupervisor", shutdown: 10000, restart: :temporary]
-    supervisor(Pooly.WorkerSupervisor, [self, mfa], opts)
+    supervisor(Pooly.WorkerSupervisor, [self(), mfa], opts)
   end
 
   defp state_name(%State{overflow: overflow, max_overflow: max_overflow, workers: workers}) when overflow < 1 do

--- a/chapter_7/pooly/version-4/lib/pooly/pool_supervisor.ex
+++ b/chapter_7/pooly/version-4/lib/pooly/pool_supervisor.ex
@@ -12,7 +12,7 @@ defmodule Pooly.PoolSupervisor do
     ]
 
     children = [
-      worker(Pooly.PoolServer, [self, pool_config])
+      worker(Pooly.PoolServer, [self(), pool_config])
     ]
 
     supervise(children, opts)

--- a/chapter_7/pooly/version-4/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-4/lib/pooly/server.ex
@@ -37,7 +37,7 @@ defmodule Pooly.Server do
 
   def init(pools_config) do
     pools_config |> Enum.each(fn(pool_config) ->
-      send(self, {:start_pool, pool_config})
+      send(self(), {:start_pool, pool_config})
     end)
 
     {:ok, pools_config}

--- a/chapter_7/pooly/version-4/mix.exs
+++ b/chapter_7/pooly/version-4/mix.exs
@@ -7,7 +7,7 @@ defmodule Pooly.Mixfile do
      elixir: "~> 1.0",
      build_embedded: Mix.env == :prod,
      start_permanent: Mix.env == :prod,
-     deps: deps]
+     deps: deps()]
   end
 
   def application do


### PR DESCRIPTION
Hello,

I'm new to Elixir and OTP, I believe that Pooly version 3 contains 2 issues - I can be wrong.

First one is kind of obvious when you `checkout` a worker for the pool and kill it. [Fix here](https://github.com/benjamintanweihao/the-little-elixir-otp-guidebook-code/compare/master...Cinderella-Man:master?expand=1#diff-e98363ed6fab98844a8d156398cd7135R109)

Second one is more subtle. When above got fixed I relised that now I'm getting 2 new workers from single killed one. Reason of that is that `WorkerSupervisor` will `restart` dead worker as well as `PoolServer` (as long as it was `checkout`ed). There's no simple solution to the problem without going too far away from book content so I most obvious solution would be to keep `WorkerSupervisor`'s `restart` to `:temporary` - [Fix is here](https://github.com/benjamintanweihao/the-little-elixir-otp-guidebook-code/compare/master...Cinderella-Man:master?expand=1#diff-27c2e90625d2b98caa67cd4ce1746ee8L10)

Please let me know what do you think :) Hope that above makes sense

Thanks,

Kamil