### PR TITLE
Error in handle_call with :restart_child - Missing parameter

### DIFF
--- a/chapter_5/thy_supervisor/lib/thy_supervisor.ex
+++ b/chapter_5/thy_supervisor/lib/thy_supervisor.ex
@@ -62,14 +62,14 @@ defmodule ThySupervisor do
     end
   end
 
-  def handle_call({:restart_child, old_pid}, _from, state) do
+  def handle_call({:restart_child, old_pid, new_spec}, _from, state) do
     case Map.fetch(state, old_pid) do
-      {:ok, child_spec} ->
-        case restart_child(old_pid, child_spec) do
+      {:ok, _child_spec} ->
+        case restart_child(old_pid, new_spec) do
           {:ok, {pid, child_spec}} ->
             new_state = state
                           |> Map.delete(old_pid)
-                          |> Map.put(pid, child_spec)
+                          |> Map.put(pid, new_spec)
             {:reply, {:ok, pid}, new_state}
           :error ->
             {:reply, {:error, "error restarting child"}, state}


### PR DESCRIPTION
Steps to reproduce the error:
iex(2)> {:ok, sup_pid} = ThySupervisor.start_link([])
{:ok, #PID<0.157.0>}
iex(3)> {:ok, child_pid} = ThySupervisor.start_child(sup_pid, {ThyWorker, :start_link, []})
{:ok, #PID<0.159.0>}
iex(4)> {:ok, child_pid} = ThySupervisor.restart_child(sup_pid, child_pid, {ThyWorker, :start_link, []})
** (EXIT from #PID<0.143.0>) evaluator process exited with reason: an exception was raised:
    ** (FunctionClauseError) no function clause matching in ThySupervisor.handle_call/3
