### PR TITLE
Link Server and worker

### DIFF
--- a/chapter_7/pooly/version-1/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-1/lib/pooly/server.ex
@@ -100,6 +100,7 @@ defmodule Pooly.Server do
 
   defp new_worker(sup) do
     {:ok, worker} = Supervisor.start_child(sup, [[]])
+    true = Process.link(worker)
     worker
   end
 

--- a/chapter_7/pooly/version-2/lib/pooly/server.ex
+++ b/chapter_7/pooly/version-2/lib/pooly/server.ex
@@ -126,7 +126,7 @@ defmodule Pooly.Server do
 
   defp new_worker(sup) do
     {:ok, worker} = Supervisor.start_child(sup, [[]])
-    Process.link(worker)
+    true = Process.link(worker)
     worker
   end
 

--- a/chapter_7/pooly/version-3/lib/pooly/pool_server.ex
+++ b/chapter_7/pooly/version-3/lib/pooly/pool_server.ex
@@ -141,7 +141,7 @@ defmodule Pooly.PoolServer do
 
   defp new_worker(sup) do
     {:ok, worker} = Supervisor.start_child(sup, [[]])
-    Process.link(worker)
+    true = Process.link(worker)
     worker
   end
 


### PR DESCRIPTION
While stepping through the code listings in the book, I noticed that 7.1.2 (page 142) describes a scenario where the `Pooly.Server` may crash when the worker does. When writing a unit test, I discovered that this was not true. The culprit is that we aren't linking the worker to the server when it is created. I have added the code from a later listing that was doing precisely this.

What are your thoughts?