### PR TITLE
refactor "Map.size" to "Enum.count"

### DIFF
--- a/chapter_5/thy_supervisor/lib/thy_supervisor.ex
+++ b/chapter_5/thy_supervisor/lib/thy_supervisor.ex
@@ -80,7 +80,7 @@ defmodule ThySupervisor do
   end
 
   def handle_call(:count_children, _from, state) do
-    {:reply, Map.size(state), state}
+    {:reply, Enum.count(state), state}
   end
 
   def handle_call(:which_children, _from, state) do


### PR DESCRIPTION
on "count_children", use the Enum.count function since Map.size is no longer supported, map fully implements the Enum protocol