### PR TITLE
No passing "child_spec" on "restart_child" call

### DIFF
--- a/chapter_5/thy_supervisor/lib/thy_supervisor.ex
+++ b/chapter_5/thy_supervisor/lib/thy_supervisor.ex
@@ -18,7 +18,7 @@ defmodule ThySupervisor do
   end
 
   def restart_child(supervisor, pid, child_spec) when is_pid(pid) do
-    GenServer.call(supervisor, {:restart_child, pid, child_spec})
+    GenServer.call(supervisor, {:restart_child, pid})
   end
 
   def count_children(supervisor) do


### PR DESCRIPTION
"restart_child" call needs to pass only pid to restart